### PR TITLE
Fix cannon ammo prototypes still exists when vtk-cannon-turret-ammo-use == 2

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -38,10 +38,10 @@ if settings.startup["vtk-cannon-turret-ammo-use"].value == 1 or
     data.raw["ammo"]["uranium-cannon-shell-magazine"].icon = path .. "/graphics/icons/uranium-cannon-shell-magazine-old.png"
     data.raw["ammo"]["explosive-uranium-cannon-shell-magazine"].icon = path .. "/graphics/icons/explosive-uranium-cannon-shell-magazine-old.png"
   end
-end
 
-if settings.startup["vtk-cannon-turret-magazine-new-icon"].value == false then
-  data.raw["ammo-category"]["cannon-shell-magazine"].icon = path .. "/graphics/icons/cannon-shell-magazine-old.png"
-else
-  data.raw["ammo-category"]["cannon-shell-magazine"].icon = path .. "/graphics/icons/cannon-shell-magazine.png"
+  if settings.startup["vtk-cannon-turret-magazine-new-icon"].value == false then
+    data.raw["ammo-category"]["cannon-shell-magazine"].icon = path .. "/graphics/icons/cannon-shell-magazine-old.png"
+  else
+    data.raw["ammo-category"]["cannon-shell-magazine"].icon = path .. "/graphics/icons/cannon-shell-magazine.png"
+  end
 end

--- a/prototypes/cannon-turret-ammo.lua
+++ b/prototypes/cannon-turret-ammo.lua
@@ -1,7 +1,8 @@
 local item_sounds = require("__base__.prototypes.item_sounds")
 local path = "__vtk-cannon-turret__"
 
-if settings.startup["vtk-cannon-turret-ammo-use"].value == 1 or 3 then
+if settings.startup["vtk-cannon-turret-ammo-use"].value == 1 or
+   settings.startup["vtk-cannon-turret-ammo-use"].value == 3 then
 
 -- New category for turret cannon shells
 data:extend(
@@ -272,5 +273,6 @@ data:extend(
   projura,
   projuraexp,
 })
+
 
 end


### PR DESCRIPTION
When vtk-cannon-turret-ammo-use == 2, the cannon ammo prototypes should not be created. This seems to be the intention of the condition `if settings.startup["vtk-cannon-turret-ammo-use"].value == 1 or 3` in `prototypes/cannon-turret-ammo.lua`. But this syntax is wrong and is always true. This PR fixes it.